### PR TITLE
Fix for when a route is null

### DIFF
--- a/src/controllers/CrudController.php
+++ b/src/controllers/CrudController.php
@@ -21,8 +21,12 @@ class CrudController extends Controller
         $route = \App::make('route');
         $this->lang = $lang;
         $this->route = $route;
-        $routeParamters = $route::current()->parameters();
-        $this->setEntity($routeParamters['entity']);
+        if($route = $route::current())
+        {
+            $routeParamters = $route::current()->parameters();
+            if(isset($routeParamters['entity']))
+                $this->setEntity($routeParamters['entity']);
+        }
     }
 
     /**


### PR DESCRIPTION
For instance in Artisan Console, command route:list throws exception due to $route::current() returns null.

Note: I'm not sure this is fully optimal, i can imagine it might cause some trouble if a route wasn't found when an entity is required.