### PR TITLE
Change to protocol relative urls

### DIFF
--- a/src/views/master.blade.php
+++ b/src/views/master.blade.php
@@ -27,10 +27,10 @@
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+        <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="//oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <link href='http://fonts.googleapis.com/css?family=Abel' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Abel' rel='stylesheet' type='text/css'>
     @if (App::getLocale() == 'fa')
       <link href="{{URL::asset('css/fonts/fonts.css')}}" rel="stylesheet">
       <link href="{{URL::asset('css/fa-fonts.css')}}" rel="stylesheet">


### PR DESCRIPTION
Change links for HTML5 Shim and Respond.js IE8 support & Google font to be protocol relative (prevents error about google font when serving from https site)