### PR TITLE
fix excel sheet upload issue

### DIFF
--- a/src/controllers/ExportImportController.php
+++ b/src/controllers/ExportImportController.php
@@ -72,8 +72,7 @@ class ExportImportController extends Controller {
 	foreach ($rows as $row) {
 		foreach ($notNullColumnNames as $notNullColumn) {
 			if (!isset($row[$notNullColumn])) {
-				$this->failed = true;
-				break;
+				unset($rows[$i]);
 			}
 		}
 	}


### PR DESCRIPTION
excel automatically adds a ton of empty rows to the end of your document. when working with notNullColumns, the import will always fail as the empty columns, created by excel are checked for the key value as well.

my change removes rows where notNullColumn is not filled in instead of failing import. so rows where a mandatory field is missing will be skipped.