### PR TITLE
align permission structure with model urls

### DIFF
--- a/src/Serverfireteam/Panel/libs/PermissionCheckMiddleware.php
+++ b/src/Serverfireteam/Panel/libs/PermissionCheckMiddleware.php
@@ -32,7 +32,7 @@ class PermissionCheckMiddleware
         }else{
             if (key_exists(2 , $urlSegments)){
 
-                $PermissionToCheck = $urlSegments[1].$urlSegments[2];
+                $PermissionToCheck = '/' . $urlSegments[1] . '/' . $urlSegments[2];
 
                 if($admin->hasPermission($PermissionToCheck)){
 

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -43,7 +43,7 @@ class dashboard
             {
                 $user = \Auth::guard('panel')->user();
                 if (! $user->hasRole('super'))
-                    if (! \Auth::guard('panel')->user()->hasPermission($modelName.'all'))
+                    if (! \Auth::guard('panel')->user()->hasPermission('/' . $modelName . '/all'))
                         continue;
                     
                 $dashboard[] = array(


### PR DESCRIPTION
# Issue: usage of permissions unclear
the permission model has "url" as input field. when using I would expect it to mimic the url structure of the models. (i.e. "/Role/all" or "/Role/edit"). Instead it performs checks for a permission like "Roleall" or "Roleedit" which isnt readable or intuitive.

# Change
the urls for those checks have been modified to mimic a readable structure: 
`/[Model]/[action]`

## Permission usage
1. Create permissions like the example below via the permission CRUD controller:
url: `/Role/all`
description: `View Roles`
2. Create new desired role
2. Assign permission to new role via role CRUD controller