### PR TITLE
Laravel 5.4 - Removed share method and replaced with singleton method.

### DIFF
--- a/src/Serverfireteam/Panel/PanelServiceProvider.php
+++ b/src/Serverfireteam/Panel/PanelServiceProvider.php
@@ -29,10 +29,10 @@ class PanelServiceProvider extends ServiceProvider
         $this->app->register('Barryvdh\Elfinder\ElfinderServiceProvider');
         
 
-        $this->app['router']->middleware('PanelAuth', 'Serverfireteam\Panel\libs\AuthMiddleware');
+        $this->app['router']->aliasMiddleware('PanelAuth', 'Serverfireteam\Panel\libs\AuthMiddleware');
         
         //middleware Permission
-        $this->app['router']->middleware(
+        $this->app['router']->aliasMiddleware(
             'PermissionPanel', 'Serverfireteam\Panel\libs\PermissionCheckMiddleware'
             );
 

--- a/src/Serverfireteam/Panel/PanelServiceProvider.php
+++ b/src/Serverfireteam/Panel/PanelServiceProvider.php
@@ -50,31 +50,31 @@ class PanelServiceProvider extends ServiceProvider
         $loader->alias('Html', 'Collective\Html\HtmlFacade');
         $loader->alias('Excel', 'Maatwebsite\Excel\Facades\Excel');
 
-        $this->app['panel::install'] = $this->app->share(function()
+        $this->app->singleton('panel::install', function()
         {
             return new \Serverfireteam\Panel\Commands\PanelCommand();
         });
 
-        $this->app['panel::crud'] = $this->app->share(function()
+        $this->app->singleton('panel::crud', function()
         {
             return new \Serverfireteam\Panel\Commands\CrudCommand();
         });
 
-        $this->app['panel::createmodel'] = $this->app->share(function()
+        $this->app->singleton('panel::createmodel', function()
         {
          $fileSystem = new Filesystem(); 
 
          return new \Serverfireteam\Panel\Commands\CreateModelCommand($fileSystem);
      });
 
-        $this->app['panel::createobserver'] = $this->app->share(function()
+        $this->app->singleton('panel::createobserver', function()
         {
          $fileSystem = new Filesystem(); 
 
          return new \Serverfireteam\Panel\Commands\CreateModelObserverCommand($fileSystem);
      });
 
-        $this->app['panel::createcontroller'] = $this->app->share(function()
+        $this->app->singleton('panel::createcontroller', function()
         {
          $fileSystem = new Filesystem();
 

--- a/src/Serverfireteam/Panel/libs/AppHelper.php
+++ b/src/Serverfireteam/Panel/libs/AppHelper.php
@@ -8,7 +8,7 @@ namespace Serverfireteam\Panel\libs;
  */
 
 class AppHelper {
-    use \Illuminate\Console\AppNamespaceDetectorTrait;
+    use \Illuminate\Console\DetectsApplicationNamespace;
 
     public function getNameSpace(){
         return $this->getAppNamespace();


### PR DESCRIPTION
Had issues with installation in a fresh laravel 5.4, I fixed it as per the following...

From Laravel 5.4 Upgrade: https://laravel.com/docs/5.4/upgrade

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead:

$container->singleton('foo', function () {
    return 'foo';
});