### PR TITLE
More updates to laravel 5.4

### DIFF
--- a/src/Serverfireteam/Panel/Commands/CreateControllerPanelCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CreateControllerPanelCommand.php
@@ -62,7 +62,7 @@ class CreateControllerPanelCommand extends GeneratorCommand {
 	 */
 	public function fire()
 	{
-            $name = $this->parseName($this->getNameInput()) . 'Controller';
+            $name = $this->qualifyClass($this->getNameInput()) . 'Controller';
 
             if ($this->files->exists($path = $this->getPath($name)))
             {

--- a/src/Serverfireteam/Panel/Commands/CreateModelObserverCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CreateModelObserverCommand.php
@@ -53,7 +53,7 @@ class CreateModelObserverCommand extends GeneratorCommand {
 	 */
 	public function fire()
 	{
-           	$name = $this->parseName($this->getNameInput());
+           	$name = $this->qualifyClass($this->getNameInput());
             
             if ($this->files->exists($path = $this->getPath($name . 'Observer')))
             {


### PR DESCRIPTION
GeneratorCommand's function parseName was renamed to qualifyClass. This affected the creation of controller, and model observer when executing:

php artisan panel:crud <entity-name>

I'm assuming php artisan panel:createcontroller <entity-name> will output the same error.