### PR TITLE
Let users add own styles/stylesheets

### DIFF
--- a/src/views/master.blade.php
+++ b/src/views/master.blade.php
@@ -24,6 +24,8 @@
     <link href="{{asset("packages/serverfireteam/panel/css/styles.css")}}" rel="stylesheet" type="text/css">
     <link href="{{asset("packages/serverfireteam/panel/font-icon/icomoon/style.css")}}" rel="stylesheet" type="text/css">
 
+    {!! Rapyd::styles() !!}
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
As of now, if a user defines some css with

```php
Rapyd::css('/my/style.css');
```

the css won't get included.

I propose that we call `{!! Rapyd::styles() !!}` in `views/master.blade.php` so users can have their own css.