### PR TITLE
Allow specify links via config

### DIFF
--- a/src/Serverfireteam/Panel/Commands/CrudCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CrudCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Serverfireteam\Panel\Commands;
 
 use Illuminate\Console\Command;
+use Serverfireteam\Panel\Link;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -42,9 +43,11 @@ class CrudCommand extends Command {
             
             $this->call('panel:createcontroller', ['name' => $crudName]);
             
-            $link = new \Serverfireteam\Panel\Link();
-            $link->getAndSave($crudName, $crudName . 's');
-            $link->save();
+            Link::create([
+                'url' => $crudName,
+                'display' => $crudName . 's',
+                'show_menu' => true,
+            ]);
             
             if ( !\Schema::hasTable($crudName) ){
                 $this->info('    The Table Corresponding to this Model does not exist in Database!!       ');

--- a/src/Serverfireteam/Panel/Facades/LinksFacade.php
+++ b/src/Serverfireteam/Panel/Facades/LinksFacade.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Serverfireteam\Panel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Serverfireteam\Panel\LinkRepository;
+
+class LinksFacade extends Facade
+{
+    protected static function getFacadeAccessor ()
+    {
+        return LinkRepository::class;
+    }
+}

--- a/src/Serverfireteam/Panel/LinkRepository.php
+++ b/src/Serverfireteam/Panel/LinkRepository.php
@@ -42,24 +42,6 @@ class LinkRepository
     }
 
     /**
-     * Get the "url" attributes of all the links
-     * @return array
-     */
-    public function getAllUrls ()
-    {
-        return $this->all()->pluck('url')->toArray();
-    }
-
-    /**
-     * Get the "url" attributes of all the links where "main" is true
-     * @return array
-     */
-    public function getMainUrls ()
-    {
-        return $this->main()->pluck('url')->toArray();
-    }
-
-    /**
      * Return whether the given URL (model name) exists amongst the "main" links
      * @param $url
      * @return bool

--- a/src/Serverfireteam/Panel/LinkRepository.php
+++ b/src/Serverfireteam/Panel/LinkRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Serverfireteam\Panel;
+
+use Illuminate\Support\Collection;
+use Serverfireteam\Panel\Links\LinkProvider;
+
+class LinkRepository
+{
+
+    /**
+     * @var LinkProvider
+     */
+    private $linkProvider;
+
+    /**
+     * LinkRepository constructor.
+     * @param LinkProvider $linkProvider
+     */
+    public function __construct (LinkProvider $linkProvider)
+    {
+        $this->linkProvider = $linkProvider;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function all ()
+    {
+        // @TODO cache
+        return $this->linkProvider->getAll();
+    }
+
+    /**
+     * Get all the links where "main" is true
+     * @return Collection
+     */
+    public function main ()
+    {
+        // @TODO cache
+        return $this->linkProvider->getMain();
+    }
+
+    /**
+     * Get the "url" attributes of all the links
+     * @return array
+     */
+    public function getAllUrls ()
+    {
+        return $this->all()->pluck('url')->toArray();
+    }
+
+    /**
+     * Get the "url" attributes of all the links where "main" is true
+     * @return array
+     */
+    public function getMainUrls ()
+    {
+        return $this->main()->pluck('url')->toArray();
+    }
+
+    /**
+     * Return whether the given URL (model name) exists amongst the "main" links
+     * @param $url
+     * @return bool
+     */
+    public function isMain ($url)
+    {
+        return $this->main()->pluck('url')->contains($url);
+    }
+}

--- a/src/Serverfireteam/Panel/Links/ConfigLinkProvider.php
+++ b/src/Serverfireteam/Panel/Links/ConfigLinkProvider.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: JM
+ * Date: 08/04/2017
+ * Time: 15:16
+ */
+
+namespace Serverfireteam\Panel\Links;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class ConfigLinkProvider implements LinkProvider
+{
+
+    /**
+     * @return Collection
+     */
+    public function getAll ()
+    {
+        // Use the links from config/panel.php
+        $config = config('panel.links');
+
+        return collect($config)->map(function ($spec, $label) {
+            if (is_int($label)) { // This is just a string without a key (short notation)
+                $label = $spec;
+                $spec  = null;
+            }
+            return [
+                'display'   => $label,
+                'url'       => data_get($spec, 'model', Str::singular($label)),
+                'show_menu' => data_get($spec, 'show_menu', true),
+                'main'      => !data_get($spec, 'custom', true),
+            ];
+        })->values();
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getMain ()
+    {
+        return $this->getAll()->filter(function ($link) {
+            return $link['main'];
+        });
+    }
+}

--- a/src/Serverfireteam/Panel/Links/DbLinkProvider.php
+++ b/src/Serverfireteam/Panel/Links/DbLinkProvider.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: JM
+ * Date: 08/04/2017
+ * Time: 15:16
+ */
+
+namespace Serverfireteam\Panel\Links;
+
+use Illuminate\Support\Collection;
+use Serverfireteam\Panel\Link;
+
+class DbLinkProvider implements LinkProvider
+{
+
+    /**
+     * @return Collection
+     */
+    public function getAll ()
+    {
+        return Link::all();
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getMain ()
+    {
+        return Link::whereMain(true)->get();
+    }
+}

--- a/src/Serverfireteam/Panel/Links/LinkProvider.php
+++ b/src/Serverfireteam/Panel/Links/LinkProvider.php
@@ -1,0 +1,22 @@
+<?php
+namespace Serverfireteam\Panel\Links;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Provides links to be shown in the dashboard
+ * @package Serverfireteam\Panel\Links
+ */
+interface LinkProvider
+{
+
+    /**
+     * @return Collection
+     */
+    public function getAll();
+
+    /**
+     * @return Collection
+     */
+    public function getMain();
+}

--- a/src/Serverfireteam/Panel/PanelServiceProvider.php
+++ b/src/Serverfireteam/Panel/PanelServiceProvider.php
@@ -4,10 +4,14 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Translation;
+use Serverfireteam\Panel\Facades\LinksFacade;
 use Serverfireteam\Panel\libs;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation;
 use Serverfireteam\Panel\Commands;
+use Serverfireteam\Panel\Links\ConfigLinkProvider;
+use Serverfireteam\Panel\Links\DbLinkProvider;
+use Serverfireteam\Panel\Links\LinkProvider;
 
 class PanelServiceProvider extends ServiceProvider
 {
@@ -80,6 +84,12 @@ class PanelServiceProvider extends ServiceProvider
 
          return new \Serverfireteam\Panel\Commands\CreateControllerPanelCommand($fileSystem);
      });
+
+        $this->app->bind(LinkProvider::class, function () {
+            return app(config('panel.links') ? ConfigLinkProvider::class : DbLinkProvider::class);
+        });
+
+        $loader->alias('Links', LinksFacade::class);
 
         $this->commands('panel::createmodel');
 

--- a/src/Serverfireteam/Panel/PanelServiceProvider.php
+++ b/src/Serverfireteam/Panel/PanelServiceProvider.php
@@ -85,7 +85,7 @@ class PanelServiceProvider extends ServiceProvider
          return new \Serverfireteam\Panel\Commands\CreateControllerPanelCommand($fileSystem);
      });
 
-        $this->app->bind(LinkProvider::class, function () {
+        $this->app->singleton(LinkProvider::class, function () {
             return app(config('panel.links') ? ConfigLinkProvider::class : DbLinkProvider::class);
         });
 

--- a/src/Serverfireteam/Panel/config/panel.php
+++ b/src/Serverfireteam/Panel/config/panel.php
@@ -20,8 +20,8 @@ return array(
     // 'links' => [
     //     'Links'       => [ // use the display name as the key
     //         'model'     => 'Link', // model name, same as "url" in the database
-    //         'custom'    => false, // if true, use own controller and model, otherwise, use built-in from panel
-    //         'show_menu' => true,
+    //         'custom'    => false, // not "main"? defaults to true
+    //         'show_menu' => true, // defaults to true
     //     ],
     //     'Roles'       => [
     //         'model'     => 'Role',
@@ -36,6 +36,20 @@ return array(
     //     'Admins'      => [
     //         'model'     => 'Admin',
     //         'custom'    => false,
+    //         'show_menu' => true,
+    //     ],
+    // ],
+
+    // Example of short notation style:
+    // 'links' => [
+    //     'Customers'
+    // ],
+
+    // This is equivalent to
+    // 'links' => [
+    //     'Customers' => [
+    //         'model'     => 'Customer',
+    //         'custom'    => true,
     //         'show_menu' => true,
     //     ],
     // ],

--- a/src/Serverfireteam/Panel/config/panel.php
+++ b/src/Serverfireteam/Panel/config/panel.php
@@ -15,6 +15,30 @@ return array(
     ),
     'logo'=>'packages/serverfireteam/panel/img/logo.png', // logo of Panel 
     'modelPath' => '', // specific model path in the app folder e.g. 'Models'
+
+    // Uncomment the section below to use links specified here rather than in the DB table "links"
+    // 'links' => [
+    //     'Links'       => [ // use the display name as the key
+    //         'model'     => 'Link', // model name, same as "url" in the database
+    //         'custom'    => false, // if true, use own controller and model, otherwise, use built-in from panel
+    //         'show_menu' => true,
+    //     ],
+    //     'Roles'       => [
+    //         'model'     => 'Role',
+    //         'custom'    => false,
+    //         'show_menu' => true,
+    //     ],
+    //     'Permissions' => [
+    //         'model'     => 'Permission',
+    //         'custom'    => false,
+    //         'show_menu' => true,
+    //     ],
+    //     'Admins'      => [
+    //         'model'     => 'Admin',
+    //         'custom'    => false,
+    //         'show_menu' => true,
+    //     ],
+    // ],
 );
     
     

--- a/src/Serverfireteam/Panel/libs/AppHelper.php
+++ b/src/Serverfireteam/Panel/libs/AppHelper.php
@@ -26,6 +26,11 @@ class AppHelper {
     	}
     }
 
+    /**
+     * For the given entity name, the the corresponding Model's class
+     * @param string $entity
+     * @return string
+     */
     public function getModel($entity) {
         if ( in_array($entity, \Serverfireteam\Panel\Link::getMainUrls()) ) {
             $modelClass = 'Serverfireteam\\Panel\\'.$entity;
@@ -36,7 +41,7 @@ class AppHelper {
             else {
                 $modelClass = $this->getNameSpace() . $entity;
             }
-            
+
         }
         return $modelClass;
     }

--- a/src/Serverfireteam/Panel/libs/AppHelper.php
+++ b/src/Serverfireteam/Panel/libs/AppHelper.php
@@ -32,7 +32,7 @@ class AppHelper {
      * @return string
      */
     public function getModel($entity) {
-        if ( in_array($entity, \Serverfireteam\Panel\Link::getMainUrls()) ) {
+        if ( \Links::isMain($entity) ) {
             $modelClass = 'Serverfireteam\\Panel\\'.$entity;
         } else {
             if (!empty(\Config::get('panel.modelPath'))) {

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -88,7 +88,7 @@ class dashboard
                     'show_menu' => data_get($spec, 'show_menu', true),
                     'main'      => !data_get($spec, 'custom', true),
                 ];
-            });
+            })->values();
         } else
             return \Serverfireteam\Panel\Link::allCached();
     }

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -41,19 +41,17 @@ class dashboard
     /**
      * Return the array of entity types (models / links)
      * to show CRUD interfaces for in the panel
+     * @param AppHelper $appHelper
      * @return array
      */
-    public function create ()
+    public function create (AppHelper $appHelper)
     {
+        return collect($this->getLinks())
 
-        $links = $this->getLinks();
-
-        $appHelper = new AppHelper();
-
-        return collect($links)
             ->filter(function ($link) {
                 return $this->showLink($link);
             })
+
             ->map(function ($link) use ($appHelper) {
 
                 $modelName = $link['url'];
@@ -68,6 +66,7 @@ class dashboard
                     'addUrl'      => 'panel/' . $modelName . '/edit',
                 ];
             })
+
             ->toArray();
     }
 

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -82,6 +82,10 @@ class dashboard
 
             // Use the links from config/panel.php
             return collect($config)->map(function ($spec, $label) {
+                if (is_int($label)) { // This is just a string without a key (short notation)
+                    $label = $spec;
+                    $spec  = null;
+                }
                 return [
                     'display'   => $label,
                     'url'       => data_get($spec, 'model', Str::singular($label)),

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -5,6 +5,7 @@ namespace Serverfireteam\Panel\libs;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Serverfireteam\Panel\LinkRepository;
 
 class dashboard
 {
@@ -45,12 +46,17 @@ class dashboard
     /**
      * Return the array of entity types (models / links)
      * to show CRUD interfaces for in the panel
-     * @param AppHelper $appHelper
+     *
+     * @param AppHelper      $appHelper
+     * @param LinkRepository $linkRepository
+     *
      * @return array
      */
-    public function create (AppHelper $appHelper)
+    public function create (AppHelper $appHelper, LinkRepository $linkRepository)
     {
-        return collect($this->getLinks())
+        // @TODO cache
+
+        return $linkRepository->all()
 
             ->filter(function ($link) {
                 return $this->showLink($link);
@@ -72,31 +78,5 @@ class dashboard
             })
 
             ->toArray();
-    }
-
-    /**
-     * Return the collection of links
-     * (either from the Link model in the database or from the panel config file)
-     * @return array|Collection
-     */
-    private function getLinks ()
-    {
-        if (($config = config('panel.links')) !== null) {
-
-            // Use the links from config/panel.php
-            return collect($config)->map(function ($spec, $label) {
-                if (is_int($label)) { // This is just a string without a key (short notation)
-                    $label = $spec;
-                    $spec  = null;
-                }
-                return [
-                    'display'   => $label,
-                    'url'       => data_get($spec, 'model', Str::singular($label)),
-                    'show_menu' => data_get($spec, 'show_menu', true),
-                    'main'      => !data_get($spec, 'custom', true),
-                ];
-            })->values();
-        } else
-            return \Serverfireteam\Panel\Link::allCached();
     }
 }

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -1,60 +1,95 @@
 <?php
+
 namespace Serverfireteam\Panel\libs;
 
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class dashboard
 {
 
+    /**
+     * Dashboard items cache
+     * @var array
+     */
     public static $dashboardItems;
 
-    public static function getItems()
+    public static function getItems ()
     {
-        if(!self::$dashboardItems) {
-            self::$dashboardItems = self::create();
+        if (!self::$dashboardItems) {
+            self::$dashboardItems = \App::call(self::class . '@create');
         }
 
         return self::$dashboardItems;
     }
 
-    public static function create()
+    /**
+     * Determine whether to show the given entity type in the panel
+     * @param $link
+     * @return bool
+     */
+    private function showLink ($link)
     {
-        $config    = \Serverfireteam\Panel\Link::allCached();
-        $dashboard = array();
+        if (!$link['show_menu']) return false;
+
+        $user = \Auth::guard('panel')->user();
+
+        return $user->hasRole('super') || $user->hasPermission('/' . $link['url'] . '/all');
+    }
+
+    /**
+     * Return the array of entity types (models / links)
+     * to show CRUD interfaces for in the panel
+     * @return array
+     */
+    public function create ()
+    {
+
+        $links = $this->getLinks();
 
         $appHelper = new AppHelper();
 
-        // Make Dashboard Items
-        foreach ($config as $value) {
+        return collect($links)
+            ->filter(function ($link) {
+                return $this->showLink($link);
+            })
+            ->map(function ($link) use ($appHelper) {
 
-    	    $modelName = $value['url'];
-            /*
-            if ( in_array($modelName, self::$urls)) {
-               $model = "Serverfireteam\\Panel\\".$modelName;
-            } else {
-               $model = $appHelper->getNameSpace() . $modelName;
-            }
-            */
-            $model = $appHelper->getModel($modelName);
+                $modelName = $link['url'];
 
-            //if (class_exists($value)) {
-            if($value['show_menu'])
-            {
-                $user = \Auth::guard('panel')->user();
-                if (! $user->hasRole('super'))
-                    if (! \Auth::guard('panel')->user()->hasPermission('/' . $modelName . '/all'))
-                        continue;
-                    
-                $dashboard[] = array(
-                    'modelName' => $modelName,
-                    'title'   => $value['display'],
-                    'count'   => $model::count(),
+                $model = $appHelper->getModel($modelName);
+
+                return [
+                    'modelName'   => $modelName,
+                    'title'       => $link['display'],
+                    'count'       => $model::count(),
                     'showListUrl' => 'panel/' . $modelName . '/all',
                     'addUrl'      => 'panel/' . $modelName . '/edit',
-                );
-            }
-            
-        }
+                ];
+            })
+            ->toArray();
+    }
 
-       return $dashboard;
+    /**
+     * Return the collection of links
+     * (either from the Link model in the database or from the panel config file)
+     * @return array|Collection
+     */
+    private function getLinks ()
+    {
+        if (($config = config('panel.links')) !== null) {
+
+            // Use the links from config/panel.php
+            return collect($config)->map(function ($spec, $label) {
+                return [
+                    'display'   => $label,
+                    'url'       => data_get($spec, 'model', Str::singular($label)),
+                    'show_menu' => data_get($spec, 'show_menu', true),
+                    'main'      => !data_get($spec, 'custom', true),
+                ];
+            });
+        } else
+            return \Serverfireteam\Panel\Link::allCached();
     }
 }

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -15,6 +15,10 @@ class dashboard
      */
     public static $dashboardItems;
 
+    /**
+     * Either retrieve the dashboard items from cache or from the config/DB if they were not yet cached
+     * @return array
+     */
     public static function getItems ()
     {
         if (!self::$dashboardItems) {

--- a/src/Serverfireteam/Panel/libs/dashboard.php
+++ b/src/Serverfireteam/Panel/libs/dashboard.php
@@ -7,8 +7,6 @@ class dashboard
 
     public static $dashboardItems;
 
-    public static $urls;
-
     public static function getItems()
     {
         if(!self::$dashboardItems) {
@@ -20,8 +18,6 @@ class dashboard
 
     public static function create()
     {
-        self::$urls = \Config::get('panel.panelControllers');
-
         $config    = \Serverfireteam\Panel\Link::allCached();
         $dashboard = array();
 

--- a/src/controllers/CrudController.php
+++ b/src/controllers/CrudController.php
@@ -82,38 +82,35 @@ class CrudController extends Controller
         $this->helper_message = $message;
     }
 
+    /**
+     * Check whether a link is defined for the given URL / model name
+     * @param $url
+     * @throws \Exception
+     */
+    private function validateEntity($url) {
+        if (!\Links::all()->pluck('url')->contains($url)) {
+            throw new \Exception('This url is not set yet!');
+        }
+    }
+
     public function returnView()
     {
-        $configs = \Serverfireteam\Panel\Link::returnUrls();
-
-        if (!isset($configs) || $configs == null) {
-            throw new \Exception('NO URL is set yet !');
-        } else if (!in_array($this->entity, $configs)) {
-            throw new \Exception('This url is not set yet!');
-        } else {
-            return \View::make('panelViews::all', array(
-             'grid'           => $this->grid,
-             'filter'         => $this->filter,
-             'title'          => $this->entity ,
-             'current_entity' => $this->entity,
-             'import_message' => (\Session::has('import_message')) ? \Session::get('import_message') : ''
-            ));
-        }
+        $this->validateEntity($this->entity);
+        return \View::make('panelViews::all', array(
+         'grid'           => $this->grid,
+         'filter'         => $this->filter,
+         'title'          => $this->entity ,
+         'current_entity' => $this->entity,
+         'import_message' => (\Session::has('import_message')) ? \Session::get('import_message') : ''
+        ));
     }
 
     public function returnEditView()
     {
-        $configs = \Serverfireteam\Panel\Link::returnUrls();
-
-        if (!isset($configs) || $configs == null) {
-            throw new \Exception('NO URL is set yet !');
-        } else if (!in_array($this->entity, $configs)) {
-            throw new \Exception('This url is not set yet !');
-        } else {
-           return \View::make('panelViews::edit', array('title'		 => $this->entity,
-					                'edit' 		 => $this->edit,
-							'helper_message' => $this->helper_message));
-        }
+        $this->validateEntity($this->entity);
+        return \View::make('panelViews::edit', array('title'		 => $this->entity,
+                                'edit' 		 => $this->edit,
+                        'helper_message' => $this->helper_message));
     }
 
     public function finalizeFilter() {

--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -34,7 +34,7 @@ class MainController extends Controller {
     try{
         $controller = \App::make($controller_path);
     }catch(\Exception $ex){
-        throw new \Exception("Can not found the Controller ( $controller_path ) ");               
+        throw new \Exception("Controller not found ( $controller_path ) ");
     }
 
     if (!method_exists($controller, $methods)){                

--- a/src/controllers/MainController.php
+++ b/src/controllers/MainController.php
@@ -18,9 +18,7 @@ class MainController extends Controller {
 
         $appHelper = new libs\AppHelper(); 
 
-        $urls = Link::getMainUrls();
-
-        if ( in_array($entity, $urls)){
+        if ( \Links::isMain($entity)){
             $controller_path = 'Serverfireteam\Panel\\'.$entity.'Controller';
         } else {           
             $panel_path = \Config::get('panel.controllers');

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -5,55 +5,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Link extends Model {
 
+    protected $fillable = ['url', 'display', 'show_menu'];
+
     protected $table = 'links';
-
-    static $cache = [];
-
-    public static function allCached($forceRefresh = false)
-    {
-        if (!isset(self::$cache['all']) || $forceRefresh) {
-            self::$cache['all'] = Link::all();
-        }
-
-        return self::$cache['all'];
-    }
-
-    public static function returnUrls($forceRefresh = false) {
-
-        if (!isset(self::$cache['all_urls']) || $forceRefresh) {
-            $configs = Link::allCached($forceRefresh);
-            self::$cache['all_urls'] =  $configs->pluck('url')->toArray();
-        }
-
-        return self::$cache['all_urls'];
-    }
-
-    public static function getMainUrls($forceRefresh = false){
-
-        if (!isset(self::$cache['main_urls']) || $forceRefresh) {
-            $configs = Link::where('main', '=', true)->get(['url']);
-            self::$cache['main_urls'] = $configs->pluck('url')->toArray();
-        }
-
-        return self::$cache['main_urls'];
-    }
-
-
-    public function getAndSave($url, $display, $show_menu = true){
-        $this->url = $url;
-        $this->display = $display;
-        $this->show_menu = $show_menu;
-        $this->save();
-    }
-
-
-    protected $fillable = array('url', 'display', 'show_menu');
-
-
-// //get roles user
-//     public function role()
-//     {
-//         return $this->hasOne('Models\Role');
-//     }
-    
 }

--- a/src/views/dashboard.blade.php
+++ b/src/views/dashboard.blade.php
@@ -58,13 +58,15 @@
             $(this).find('.pull-right .add').addClass('panel-'+color[pointer]);
             pointer++;
         })
-        // check for update of laravelpanel 
+        @unless($version == 'dev-master')
+        // check for update of laravelpanel
         $.getJSON( "http://api.laravelpanel.com/checkupdate/{{ $version }}", function( data ) {
           if(data.needUpdate){
             $(".update a").text(data.text);
             $(".update").removeClass('hide');
           }
         })
+        @endunless
         
     })
 </script>

--- a/src/views/dashboard.blade.php
+++ b/src/views/dashboard.blade.php
@@ -12,8 +12,7 @@
             <!-- /.row -->
             <div class="row box-holder">
                 
-                @if(is_array(\Serverfireteam\Panel\Link::returnUrls()))
-                    @foreach (Serverfireteam\Panel\libs\dashboard::getItems() as $box)
+                @foreach (Serverfireteam\Panel\libs\dashboard::getItems() as $box)
                     <div class="col-lg-3 col-md-6">
                         <div class="panel ">
                             <div class="panel-heading">
@@ -37,8 +36,7 @@
                                 </div>
                         </div>
                     </div>
-                    @endforeach
-                @endif
+                @endforeach
 
 
             </div>

--- a/src/views/noConfigFile.blade
+++ b/src/views/noConfigFile.blade
@@ -1,9 +1,0 @@
-@extends('panelViews::master')
-@section('bodyClass')
-dashboard
-@stop
-@section('body')
-
-
-
-@stop


### PR DESCRIPTION
Performed some refactoring and code clean-up and added the ability to specify the links to display as an array in config/panel.php

Example

```php


    // Uncomment the section below to use links specified here rather than in the DB table "links"
    // 'links' => [
    //     'Links'       => [ // use the display name as the key
    //         'model'     => 'Link', // model name, same as "url" in the database
    //         'custom'    => false, // not "main"? defaults to true
    //         'show_menu' => true, // defaults to true
    //     ],
    //     'Roles'       => [
    //         'model'     => 'Role',
    //         'custom'    => false,
    //         'show_menu' => true,
    //     ],
    //     'Permissions' => [
    //         'model'     => 'Permission',
    //         'custom'    => false,
    //         'show_menu' => true,
    //     ],
    //     'Admins'      => [
    //         'model'     => 'Admin',
    //         'custom'    => false,
    //         'show_menu' => true,
    //     ],
    // ],

    // Example of short notation style:
    // 'links' => [
    //     'Customers'
    // ],

    // This is equivalent to
    // 'links' => [
    //     'Customers' => [
    //         'model'     => 'Customer',
    //         'custom'    => true,
    //         'show_menu' => true,
    //     ],
    // ],

```