### PR TITLE
Only publish package assets

### DIFF
--- a/src/Serverfireteam/Panel/Commands/PanelCommand.php
+++ b/src/Serverfireteam/Panel/Commands/PanelCommand.php
@@ -39,7 +39,7 @@ class PanelCommand extends Command {
 
 	    $this->call('elfinder:publish');
 
-            $this->call('vendor:publish');
+            $this->call('vendor:publish', array('--provider' => '\Serverfireteam\Panel\PanelServiceProvider'));
 
             $this->call('migrate', array('--path' => 'vendor/serverfireteam/panel/src/database/migrations'));
 


### PR DESCRIPTION
When running `php artisan panel:install`, the working project would get littered with configs, views and other assets from **all** installed packages that publish assets because the command `php artisan vendor:publish` would get invoked. This PR adds the `--provider` parameter to that command so that only assets related to the panel package get published.