### PR TITLE
Switch fire to handle for L5.5 compatibility

### DIFF
--- a/src/Serverfireteam/Panel/Commands/CreateControllerPanelCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CreateControllerPanelCommand.php
@@ -60,7 +60,7 @@ class CreateControllerPanelCommand extends GeneratorCommand {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
             $name = $this->qualifyClass($this->getNameInput()) . 'Controller';
 

--- a/src/Serverfireteam/Panel/Commands/CreateModelCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CreateModelCommand.php
@@ -39,9 +39,9 @@ class CreateModelCommand extends GeneratorCommand {
 	 * fire model and observer model class
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
-		parent::fire();
+		parent::handle();
 
         $this->call('panel:createobserver', ['name' => $this->argument('name')]);
 	}

--- a/src/Serverfireteam/Panel/Commands/CreateModelObserverCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CreateModelObserverCommand.php
@@ -51,7 +51,7 @@ class CreateModelObserverCommand extends GeneratorCommand {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
            	$name = $this->qualifyClass($this->getNameInput());
             

--- a/src/Serverfireteam/Panel/Commands/CrudCommand.php
+++ b/src/Serverfireteam/Panel/Commands/CrudCommand.php
@@ -32,7 +32,7 @@ class CrudCommand extends Command {
 	 * Execute the console command.
 	 *
 	 */
-	public function fire()
+	public function handle()
 	{
        
             $this->info('            [ ServerFireTeam Panel Crud Generator ]       ');

--- a/src/Serverfireteam/Panel/Commands/PanelCommand.php
+++ b/src/Serverfireteam/Panel/Commands/PanelCommand.php
@@ -33,7 +33,7 @@ class PanelCommand extends Command {
 	 * Execute the console command.
 	 *
 	 */
-	public function fire()
+	public function handle()
 	{
             $this->info('        [ Welcome to ServerFireTeam Panel Installation ]       ');
 


### PR DESCRIPTION
This makes a few minor changes to commands according to https://laravel.com/docs/master/upgrade#upgrade-5.5.0

Specifically it:

- Renames `fire` methods in Artisan commands to `handle`