### PR TITLE
Admin Filter - First Name bug

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -20,7 +20,7 @@ class AdminController extends CrudController{
 
         $this->filter = \DataFilter::source(Admin::with('roles'));
         $this->filter->add('id', 'ID', 'text');
-        $this->filter->add('firstname', 'First name', 'text');
+        $this->filter->add('first_name', 'First name', 'text');
         $this->filter->add('last_name', 'Last Name', 'text');
         $this->filter->add('email', 'Email', 'text');
         $this->filter->submit('search');


### PR DESCRIPTION
When Admins are filtered by First Name the field behind the filter was defined incorrectly (firstname instead of first_name).